### PR TITLE
Fix coordinate system mismatch in frame capture

### DIFF
--- a/Examples/LARScan/LARScan/ViewController.swift
+++ b/Examples/LARScan/LARScan/ViewController.swift
@@ -235,8 +235,10 @@ class ViewController: UIViewController, ARSCNViewDelegate, ARSessionDelegate, CL
 	func snap() {
 		guard let frame = sceneView.session.currentFrame else { return }
 		AudioServicesPlaySystemSound(SystemSoundID(1108))
+		// Convert camera transform from ARKit coordinates to map-local coordinates
+		let mapLocalTransform = mapNode.simdConvertTransform(frame.camera.transform, from: sceneView.scene.rootNode)
 		Task.detached(priority: .low) { [self] in
-			await mapper.mapper.addFrame(frame)
+			await mapper.mapper.addFrame(frame, transform: mapLocalTransform)
 //			await mapper.mapper.writeMetadata()
 		}
 	}

--- a/Sources/LocalizeAR-ObjC/include/LARMapper.h
+++ b/Sources/LocalizeAR-ObjC/include/LARMapper.h
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addLocation:(CLLocation*)location NS_SWIFT_NAME( addLocation(_:) );
 
 #if TARGET_OS_IPHONE
-    - (void)addFrame:(ARFrame*)frame NS_SWIFT_NAME( addFrame(_:) );
+    - (void)addFrame:(ARFrame*)frame transform:(simd_float4x4)transform NS_SWIFT_NAME( addFrame(_:transform:) );
 #endif
 
 @end

--- a/Sources/LocalizeAR-ObjC/src/LARMapper.mm
+++ b/Sources/LocalizeAR-ObjC/src/LARMapper.mm
@@ -67,14 +67,14 @@ namespace fs = std::filesystem;
 
 #if TARGET_OS_IPHONE
 
-- (void)addFrame:(ARFrame*)frame {
+- (void)addFrame:(ARFrame*)frame transform:(simd_float4x4)transform {
     CVPixelBufferRef imageBuffer = frame.capturedImage;
     CVPixelBufferRef depthBuffer = frame.smoothedSceneDepth.depthMap;
     CVPixelBufferRef confidenceBuffer = frame.smoothedSceneDepth.confidenceMap;
     CVPixelBufferLockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferLockBaseAddress(depthBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferLockBaseAddress(confidenceBuffer, kCVPixelBufferLock_ReadOnly);
-    
+
     // Convert inputs
     cv::Mat image = [LARConversion matFromBuffer:imageBuffer planeIndex:0 type: CV_8UC1];
     cv::Mat depth = [LARConversion matFromBuffer:depthBuffer planeIndex:0 type: CV_32FC1];
@@ -82,10 +82,10 @@ namespace fs = std::filesystem;
     lar::Frame aFrame;
     aFrame.timestamp = [LARConversion timestampFromInterval:frame.timestamp];
     aFrame.intrinsics = [LARConversion eigenFromSIMD3:frame.camera.intrinsics].cast<double>();
-    aFrame.extrinsics = [LARConversion eigenFromSIMD4:frame.camera.transform].cast<double>();
-    
+    aFrame.extrinsics = [LARConversion eigenFromSIMD4:transform].cast<double>();
+
     _internal->addFrame(aFrame, image, depth, confidence);
-    
+
     CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferUnlockBaseAddress(depthBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferUnlockBaseAddress(depthBuffer, kCVPixelBufferLock_ReadOnly);

--- a/Sources/LocalizeAR-ObjC/src/LARMapper.mm
+++ b/Sources/LocalizeAR-ObjC/src/LARMapper.mm
@@ -88,7 +88,7 @@ namespace fs = std::filesystem;
 
     CVPixelBufferUnlockBaseAddress(imageBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferUnlockBaseAddress(depthBuffer, kCVPixelBufferLock_ReadOnly);
-    CVPixelBufferUnlockBaseAddress(depthBuffer, kCVPixelBufferLock_ReadOnly);
+    CVPixelBufferUnlockBaseAddress(confidenceBuffer, kCVPixelBufferLock_ReadOnly);
 }
 
 #endif


### PR DESCRIPTION
Add transform parameter to addFrame to allow passing camera poses in map-local coordinates instead of ARKit world coordinates, ensuring consistent coordinate frames across all stored mapping data.