### PR TITLE
Fix macOS build regressions in LARImageFrame + LARExplorer

### DIFF
--- a/Examples/LARExplorer/LARExplorer/Services/TestLocalizationService.swift
+++ b/Examples/LARExplorer/LARExplorer/Services/TestLocalizationService.swift
@@ -285,7 +285,7 @@ class TestLocalizationService: ObservableObject {
         // The frame's recorded camera pose (map coordinates), same frame as the localized
         // transform — so positionDifference reflects the localization error vs. where the
         // frame was originally captured. extrinsics is float32; widen to double.
-        return simd_double4x4(frame.extrinsics)
+        return frame.transform
     }
     
     /// Build a column-major simd_double4x4 from the row-major [[Double]] returned by

--- a/Sources/LocalizeAR/LARImageFrame.swift
+++ b/Sources/LocalizeAR/LARImageFrame.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-#if canImport(ARKit)
+#if os(iOS)
 import ARKit
 #endif
 
@@ -50,7 +50,7 @@ public struct LARImageFrame {
     }
 }
 
-#if canImport(ARKit)
+#if os(iOS)
 public extension LARImageFrame {
     /// Copy the full-resolution luma (grayscale) plane out of an `ARFrame` into an owned buffer,
     /// so the `ARFrame` can return to ARKit's pool immediately. Returns nil if the buffer's base


### PR DESCRIPTION
Two macOS-only build breaks slipped in over the last few days because validation was done on iOS simulator only:

1. LARImageFrame.swift guarded its ARKit code with `#if canImport(ARKit)`. On the Xcode 26 macOS SDK canImport(ARKit) is true, but `ARFrame` still doesn't exist there, so the macOS build failed with "cannot find type 'ARFrame'". Switch to `#if os(iOS)`, matching every other ARFrame user in the package (LARTracker.swift, LARFilteredTracker.swift).

2. TestLocalizationService.getFrameTransform used `simd_double4x4(frame.extrinsics)`, which has no matching initializer (there is no float->double matrix-widening init), so it never compiled on macOS. Use the existing `LARFrame.transform` helper, which performs the float32->double widening correctly.